### PR TITLE
Parametricization (is that a word)

### DIFF
--- a/bearing.scad
+++ b/bearing.scad
@@ -1,7 +1,10 @@
 steel = [0.8, 0.8, 0.9];
 
 module bearing(id, od, w) {
-    color(steel) rotate([90, 0, 0]) difference() {
+    translate([0,w/2,0])
+    color(steel) 
+    render()
+    rotate([90, 0, 0]) difference() {
 		cylinder(h=w, r=od/2, center=true);
 		cylinder(h=w*2, r=id/2, center=true);
     }
@@ -10,7 +13,8 @@ module bearing(id, od, w) {
 bearing(8, 22, 7); // 608 skateboard ball bearing.
 
 module lm8uu() {
-    color(steel) difference() {
+    translate([0,0,25/2])
+    color(steel) render() difference() {
         cylinder(h=25, r=7.5, center=true);
         cylinder(h=30, r=4, center=true);
     }

--- a/carriage.scad
+++ b/carriage.scad
@@ -1,5 +1,7 @@
+include <configuration.scad>
+
 width = 76;
-height = 24;
+height = carriage_height;
 
 offset = 25;
 cutout = 13;
@@ -63,6 +65,7 @@ module belt_mount() {
 }
 
 module carriage() {
+  translate([0, 0, height/2]) 
   union() {
     for (x = [-30, 30]) {
       translate([x, 0, 0]) lm8uu_mount(d=15, h=24);
@@ -72,7 +75,7 @@ module carriage() {
       union() {
         translate([0, -5.6, 0])
           cube([50, 5, height], center=true);
-        translate([0, -22, -height/2+4])
+        translate([0, -carriage_hinge_offset, -height/2+4])
           parallel_joints(16);
       }
       // Screw hole for adjustable top endstop.
@@ -90,7 +93,7 @@ module carriage() {
   }
 }
 
-translate([0, 0, height/2]) carriage();
+carriage();
 
 // Uncomment the following lines to check endstop alignment.
 // use <idler_end.scad>;

--- a/configuration.scad
+++ b/configuration.scad
@@ -1,0 +1,11 @@
+motor_end_height=44;
+idler_end_height=28;
+carriage_height=24;
+platform_thickness=8;
+bed_thickness=12;
+pcb_thickness=2;
+rod_length=120;
+smooth_rod_length=300;
+tower_radius = 120;
+platform_hinge_offset=33;
+carriage_hinge_offset=22;

--- a/idler_end.scad
+++ b/idler_end.scad
@@ -1,6 +1,7 @@
-use <bracket.scad>;
+include <configuration.scad>
+use <bracket.scad>
 
-h = 28; // Total height.
+h = idler_end_height; // Total height.
 tilt = 2; // Tilt bearings upward (the timing belt is pulling pretty hard).
 
 module bearing_mount() {
@@ -12,6 +13,7 @@ x = 17.7; // Micro switch center.
 y = 16; // Micro switch center.
 
 module idler_end() {
+  translate([0, 0, h/2]) 
   difference() {
     union() {
       bracket(h);
@@ -42,4 +44,4 @@ module idler_end() {
   }
 }
 
-translate([0, 0, h/2]) idler_end();
+idler_end();

--- a/motor_end.scad
+++ b/motor_end.scad
@@ -1,10 +1,12 @@
-use <bracket.scad>;
+include <configuration.scad>
+use <bracket.scad>
 
-h = 44; // Total height.
+h = motor_end_height; // Total height.
 m = 29; // Motor mounting screws distance (center to center)
 
 module motor_end() {
-  difference() {
+    translate([0, 0, h/2]) 
+    difference() {
     union() {
       bracket(h);
       for (x = [-30, 30]) {
@@ -40,4 +42,4 @@ module motor_end() {
   }
 }
 
-translate([0, 0, h/2]) motor_end();
+motor_end();

--- a/nema.scad
+++ b/nema.scad
@@ -10,7 +10,8 @@ motor_screw = 15.5;
 motor_diagonal = sqrt(2 * motor_screw * motor_screw);
 
 module nema17(length) {
-  color([0.4, 0.4, 0.4]) {
+  color([0.4, 0.4, 0.4]) 
+  render() {
     translate([0, -length/2-17, 0])
       intersection() {
       cube([42, length, 42], center=true);

--- a/platform.scad
+++ b/platform.scad
@@ -1,33 +1,37 @@
-use <carriage.scad>;
+include <configuration.scad>
+use <carriage.scad>
+
+h=platform_thickness;
 
 cutout = 12.5;
 inset = 6;
 
 module platform() {
+  translate([0, 0, h/2]) 
   difference() {
     union() {
       for (a = [0:120:359]) {
         rotate([0, 0, a]) {
-          translate([0, -33, 0]) parallel_joints();
+          translate([0, -platform_hinge_offset, 0]) parallel_joints();
           // Close little triangle holes.
-          translate([0, 31, 0]) cylinder(r=5, h=8, center=true);
+          translate([0, 31, 0]) cylinder(r=5, h=h, center=true);
           // Holder for adjustable bottom endstops.
-          translate([0, 45, 0]) cylinder(r=5, h=8, center=true);
+          translate([0, 45, 0]) cylinder(r=5, h=h, center=true);
         }
       }
-      cylinder(r=30, h=8, center=true);
+      cylinder(r=30, h=h, center=true);
     }
-    cylinder(r=20, h=20, center=true);
-    for (a = [0:60:359]) {
-      rotate([0, 0, a]) {
+    cylinder(r=20, h=h+12, center=true);
+    for (a = [0:2]) {
+      rotate(a*120) {
         translate([0, -25, 0])
-          cylinder(r=2.2, h=9, center=true, $fn=12);
+          cylinder(r=2.2, h=h+1, center=true, $fn=12);
         // Screw holes for adjustable bottom endstops.
         translate([0, 45, 0])
-          cylinder(r=1.5, h=9, center=true, $fn=12);
+          cylinder(r=1.5, h=h+1, center=true, $fn=12);
       }
     }
   }
 }
 
-translate([0, 0, 4]) platform();
+platform();

--- a/rod.scad
+++ b/rod.scad
@@ -1,6 +1,7 @@
-use <jaws.scad>;
+include <configuration.scad>
+use <jaws.scad>
 
-l = 250;
+l = rod_length;
 h = 7;
 r = h/2 / cos(30);
 
@@ -31,7 +32,8 @@ module wipers() {
 }
 
 // Rod with two Y shaped rod ends.
-module rod() {
+module rod(l) {
+  translate([l/2,0,0])
   union() {
     translate([-l/2, 0, 0]) jaws();
     translate([l/2, 0, 0]) rotate([0, 0, 180]) jaws();
@@ -40,11 +42,21 @@ module rod() {
   }
 }
 
-rotate([0, 0, 45]) rod();
+module printable_rod(l)
+{
+	// Print platform.
+	bed = 8*25.4; // 8x8 inches.
+	% translate([0, 0, -1]) cube([bed, bed, 2], center=true);
 
-// If your nozzle doesn't ooze at all, you can comment the next line out.
-rotate([0, 0, 45]) wipers();
+	rotate(45)
+	translate([-l/2,0,h/2])
+	rod(l=l);
 
-// Print platform.
-bed = 8*25.4; // 8x8 inches.
-% translate([0, 0, -h/2-1]) cube([bed, bed, 2], center=true);
+	// If your nozzle doesn't ooze at all, you can comment the next line out.
+	translate([0,0,h/2])
+	rotate(45)
+	wipers();
+}
+
+rod(l=l);
+//printable_rod(l=l);

--- a/rostock.scad
+++ b/rostock.scad
@@ -1,3 +1,4 @@
+include <configuration.scad>;
 use <belt.scad>;
 use <bearing.scad>;
 use <nema.scad>;
@@ -9,57 +10,107 @@ use <rod.scad>;
 
 aluminum = [0.9, 0.9, 0.9];
 steel = [0.8, 0.8, 0.9];
+use_stls=false;
 
-tower_radius = 154;
-joint_radius = 108;
-motor_radius = 165;
-carriage_z = 300;
-rod_length = 250;
-z0 = 120;
+//build radius for animation.
+br=50;
 
-module smooth_rod(z) {
-	color(steel) cylinder(r=4, h=762);
-	translate([0, 0, z]) lm8uu();
+platformxyz=[cos($t*360)*br,sin($t*360)*br,30];
+
+belt_length=smooth_rod_length-motor_end_height/2-idler_end_height/2;
+
+module smooth_rod() 
+{
+	color(steel) cylinder(r=4, h=smooth_rod_length);
 }
 
-module tower(z) {
-	translate([0, tower_radius, 0]) {
-		translate([0, 0, 30]) rotate([0, 0, 180]) motor_end();
-		translate([30, 0, 0]) smooth_rod(z0+z-14);
-		translate([-30, 0, 0]) smooth_rod(z0+z-14);
-		translate([0, 0, z0+z-14]) rotate([0, 180, 0]) carriage();
-	}
-	translate([0, motor_radius, 0]) {
-		translate([0, 0, 30]) nema17(47);
+module tower(height) 
+{
+	translate([0, tower_radius, 0]) 
+	{
+		translate([0, 0, motor_end_height]) 
+		rotate([180,0,0])
+		if (use_stls) import ("motor_end.stl"); else render() motor_end();
+
+		translate([0, 0, smooth_rod_length-idler_end_height]) 
+		rotate(180)
+		if (use_stls) import ("idler_end.stl"); else idler_end();
+
+		translate([30, 0, 0]) smooth_rod();
+		translate([-30, 0, 0]) smooth_rod();
+
+		translate([0, 0, motor_end_height+bed_thickness+pcb_thickness+8+platformxyz[2]+height]) 
+		rotate([0, 180, 0]) 
+		{
+			if (use_stls) import ("carriage.stl"); else render() carriage();
+			for(j=[-30,30])
+			translate([j,0,0])
+			lm8uu();
+		}
+
+		translate([0, 17-10, motor_end_height/2]) nema17(47);
+
 		// Ball bearings for timing belt
-		translate([7, 0, 750]) bearing(8, 22, 7);
+		translate([0,-4, smooth_rod_length-28/2]) 
+		bearing(8, 22, 7);
+
 		// Timing belt
-		translate([-12, 0, 390]) rotate([0, 90, 0]) timing_belt(720);
-		translate([12, 0, 390]) rotate([0, 90, 0]) timing_belt(720);
+		translate([-22/2,-4+7/2, belt_length/2+motor_end_height/2]) 
+		rotate([0, 90, 0]) 
+		timing_belt(belt_length);
+
+		translate([22/2,-4+7/2, belt_length/2+motor_end_height/2]) 
+		rotate([0, 90, 0]) 
+		timing_belt(belt_length);
 	}
 }
 
-module rod_pair(x, y, rotate_z, elevation, azimuth) {
-	translate([x, y, z0+94]) {
-		rotate([0, 0, rotate_z]) translate([25, 82, 0])
-			rotate([0, 0, azimuth]) rotate([elevation, 0, 0])
-			rotate([-azimuth, 0, 90]) rotate([90, 0, 0]) rod(rod_length);
-		rotate([0, 0, rotate_z]) translate([-25, 82, 0])
-			rotate([0, 0, azimuth]) rotate([elevation, 0, 0])
-			rotate([-azimuth, 0, 90]) rotate([90, 0, 0]) rod(rod_length);
-	}
+module rod_pair(lean_y,lean_x)
+{
+	for(i=[-1,1])
+	translate([25*i,platform_hinge_offset,0])
+	rotate([lean_x,0,0])
+	rotate([0,lean_y,0])
+	rotate([0, -90, 0]) 
+	if (use_stls) import ("rod.stl"); else 
+	rod(rod_length);
 }
 
-translate([0, 0, -160]) {
-	for (a = [0:120:359]) rotate([0, 0, a]) {
-		tower(215);
-		rod_pair(0, 0, a, elevation=67, azimuth=0);
+module rostock() 
+{
+	for(i=[0:2])
+	assign(angle=120*i)
+	assign(carriage_xy=[0,tower_radius-carriage_hinge_offset],
+		platform_xy=[platformxyz[0]*cos(angle)+platformxyz[1]*sin(angle),
+		platformxyz[1]*cos(angle)-platformxyz[0]*sin(angle)+
+		platform_hinge_offset])
+	assign(rod_dist=carriage_xy-platform_xy)
+	assign(dist=sqrt(rod_dist[0]*rod_dist[0]+rod_dist[1]*rod_dist[1]))
+	assign (height=sqrt(rod_length*rod_length-dist*dist))
+	assign(lean_y=90-acos(rod_dist[0]/rod_length),
+		 lean_x=-atan2(rod_dist[1],height))
+	{
+		rotate(angle)
+		tower(height);
+
+		translate(platformxyz)
+		rotate(angle)
+		translate([0,0,motor_end_height+bed_thickness+pcb_thickness+
+			platform_thickness/2])
+		rod_pair(lean_y,lean_x);
 	}
 
-	translate([0, 0, 100]) rotate([0, 0, 60]) platform();
+	translate(platformxyz) 
+	translate([0, 0, motor_end_height+bed_thickness+pcb_thickness]) 
+	rotate([0, 0, 60]) 
+	if (use_stls) import ("platform.stl"); else platform();
 
-	% translate([0, 0, 58])
-		  cylinder(r=tower_radius*1.11, h=12, center=true, $fn=6);
-	color([0.9, 0, 0]) translate([0, 0, 65])
-		cube([215, 215, 2], center=true);
+	% translate([0, 0, motor_end_height+bed_thickness/2])
+	cylinder(r=(tower_radius-8/2)/cos(30), h=bed_thickness, center=true, $fn=6);
+
+	color([0.9, 0, 0]) 
+	translate([0, 0, motor_end_height+bed_thickness+pcb_thickness/2])
+	cube([tower_radius*1.4, tower_radius*1.4, pcb_thickness], center=true);
 }
+
+rostock();


### PR DESCRIPTION
Made the fully assembled model in rostock.scad more parametric.
configuration.scad added to include some parameters that are needed in both the part models and the full assembly.
Some components have been moved to make the full assembly easier.
Full assembly allows the direct use of the models, or importing stls (which is much faster to help with animation generation).
Full assembly has parametric position of the platform, and the position of the carriages and rods is calculated from that.
